### PR TITLE
Grid data structures, rustfmt, fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .criterion
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "abm"
 version = "0.0.1"
-authors = ["Alessia Antelmi <aantelmi@unisa.it>","Matteo D'Auria <matdauria@unisa.it>","Daniele De Vinco <danieledevinco1996@gmail.com", "Carmine Spagnuolo <spagnuolocarmine@gmail.com>"]
+authors = ["Alessia Antelmi <aantelmi@unisa.it>", "Matteo D'Auria <matdauria@unisa.it>", "Daniele De Vinco <danieledevinco1996@gmail.com", "Carmine Spagnuolo <spagnuolocarmine@gmail.com>"]
 edition = "2018"
 license = "MIT"
-keywords = ["discrete", "simulation","agent based model","agent based simulation"]
-categories = ["science", "simulation","agent based model"]
+keywords = ["discrete", "simulation", "agent based model", "agent based simulation"]
+categories = ["science", "simulation", "agent based model"]
 readme = "README.md"
 homepage = "https://github.com/spagnuolocarmine/abm"
 repository = "https://github.com/spagnuolocarmine/abm"
@@ -36,7 +36,3 @@ objc = "0.2.7"
 [[bench]]
 name = "benchmark"
 harness = false
-
-[[bin]]
-name = "boids"
-path = "examples/boids_ui.rs"

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ impl Bird {
     pub fn new(id: u128, pos: Real2D, last_d: Real2D) -> Self {
         Bird {id, pos, last_d}
     }
-    pub fn avoidance (self, vec: &Vec<Bird>) -> Real2D {..}
-    pub fn cohesion (self, vec: &Vec<Bird>) -> Real2D {..}
-    pub fn consistency (self, vec: &Vec<Bird>) -> Real2D {..}
+    pub fn avoidance (self, _vec: &Vec<Bird>) -> Real2D {..}
+    pub fn cohesion (self, _vec: &Vec<Bird>) -> Real2D {..}
+    pub fn consistency (self, _vec: &Vec<Bird>) -> Real2D {..}
  }
-impl Location2D for Bird {
+impl Location2D<Real2D> for Bird {
     fn get_location(self) -> Real2D { self.pos }
     fn set_location(&mut self, loc: Real2D) { self.pos = loc; }
 }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -5,21 +5,20 @@ extern crate criterion;
 #[macro_use]
 extern crate lazy_static;
 
-
-use abm::field2D::toroidal_transform;
-use abm::field2D::toroidal_distance;
-use rand::Rng;
-use abm::field2D::Field2D;
-use std::hash::Hasher;
-use std::hash::Hash;
-use abm::location::Real2D;
-use abm::location::Location2D;
-use criterion::Criterion;
-use std::time::{Instant};
-use std::fmt;
 use abm::agent::Agent;
+use abm::field_2d::toroidal_distance;
+use abm::field_2d::toroidal_transform;
+use abm::field_2d::Field2D;
+use abm::location::Location2D;
+use abm::location::Real2D;
 use abm::schedule::Schedule;
+use criterion::Criterion;
+use rand::Rng;
 use std::default::Default;
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::time::Instant;
 
 use std::sync::Mutex;
 
@@ -28,19 +27,18 @@ static STEP: u128 = 100;
 static NUM_AGENT: u128 = 10000;
 static WIDTH: f64 = 150.0;
 static HEIGTH: f64 = 150.0;
-static DISCRETIZATION: f64 = 10.0/1.5;
+static DISCRETIZATION: f64 = 10.0 / 1.5;
 static TOROIDAL: bool = true;
-static COHESION : f64 = 1.0;
-static AVOIDANCE : f64 = 1.0;
-static RANDOMNESS : f64 = 1.0;
-static CONSISTENCY : f64 = 1.0;
-static MOMENTUM : f64 = 1.0;
-static JUMP : f64 = 0.7;
-
-
+static COHESION: f64 = 1.0;
+static AVOIDANCE: f64 = 1.0;
+static RANDOMNESS: f64 = 1.0;
+static CONSISTENCY: f64 = 1.0;
+static MOMENTUM: f64 = 1.0;
+static JUMP: f64 = 0.7;
 
 lazy_static! {
-    static  ref GLOBAL_STATE: Mutex<State> = Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
+    static ref GLOBAL_STATE: Mutex<State> =
+        Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -50,20 +48,28 @@ fn criterion_benchmark(c: &mut Criterion) {
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
 
-
 fn schedule_test() {
-    
     let mut rng = rand::thread_rng();
     let mut schedule: Schedule<Bird> = Schedule::new();
     assert!(schedule.events.is_empty());
 
-    for bird_id in 0..NUM_AGENT{
-
+    for bird_id in 0..NUM_AGENT {
         let r1: f64 = rng.gen();
         let r2: f64 = rng.gen();
-        let last_d = Real2D {x: 0.0, y: 0.0};
-        let bird = Bird::new(bird_id, Real2D{x: WIDTH*r1, y: HEIGTH*r2}, last_d);
-        GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird, bird.pos);
+        let last_d = Real2D { x: 0.0, y: 0.0 };
+        let bird = Bird::new(
+            bird_id,
+            Real2D {
+                x: WIDTH * r1,
+                y: HEIGTH * r2,
+            },
+            last_d,
+        );
+        GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(bird, bird.pos);
         schedule.schedule_repeating(bird, 0.0, 0);
     }
 
@@ -71,20 +77,20 @@ fn schedule_test() {
 
     let start = Instant::now();
 
-    for _ in 1..STEP{
+    for _ in 1..STEP {
         schedule.step();
     }
-
 
     let duration = start.elapsed();
 
     println!("Time elapsed in testing schedule is: {:?}", duration);
-    println!("Step for seconds: {:?}", STEP as f64/(duration.as_secs() as f64));
-
-
+    println!(
+        "Step for seconds: {:?}",
+        STEP as f64 / (duration.as_secs() as f64)
+    );
 }
 
-pub struct State{
+pub struct State {
     pub field1: Field2D<Bird>,
 }
 
@@ -97,7 +103,7 @@ impl State {
 }
 
 #[derive(Clone, Copy)]
-pub struct Bird{
+pub struct Bird {
     pub id: u128,
     pub pos: Real2D,
     pub last_d: Real2D,
@@ -105,16 +111,12 @@ pub struct Bird{
 
 impl Bird {
     pub fn new(id: u128, pos: Real2D, last_d: Real2D) -> Self {
-        Bird {
-            id,
-            pos,
-            last_d,
-        }
+        Bird { id, pos, last_d }
     }
 
-    pub fn avoidance (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn avoidance(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -127,26 +129,32 @@ impl Bird {
             if self != vec[i] {
                 let dx = toroidal_distance(self.pos.x, vec[i].pos.x, WIDTH);
                 let dy = toroidal_distance(self.pos.y, vec[i].pos.y, HEIGTH);
-                let square = (dx*dx + dy*dy).sqrt();
+                let square = (dx * dx + dy * dy).sqrt();
                 count += 1;
-                x += dx/(square*square) + 1.0;
-                y += dy/(square*square) + 1.0;
+                x += dx / (square * square) + 1.0;
+                y += dy / (square * square) + 1.0;
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         } else {
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         }
     }
 
-    pub fn cohesion (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn cohesion(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -165,12 +173,18 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         } else {
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         }
     }
@@ -178,21 +192,21 @@ impl Bird {
     pub fn randomness(self) -> Real2D {
         let mut rng = rand::thread_rng();
         let r1: f64 = rng.gen();
-        let x = r1*2.0 -1.0;
+        let x = r1 * 2.0 - 1.0;
         let r2: f64 = rng.gen();
-        let y = r2*2.0 -1.0;
+        let y = r2 * 2.0 - 1.0;
 
-        let square = (x*x + y*y).sqrt();
+        let square = (x * x + y * y).sqrt();
         let real = Real2D {
-            x: 0.05*x/square,
-            y: 0.05*y/square,
+            x: 0.05 * x / square,
+            y: 0.05 * y / square,
         };
         return real;
     }
 
-    pub fn consistency (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn consistency(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -211,12 +225,15 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/count as f64, y: y/count as f64};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / count as f64,
+                y: y / count as f64,
+            };
             return real;
         } else {
-            let real = Real2D {x: x, y: y};
+            let real = Real2D { x: x, y: y };
             return real;
         }
     }
@@ -224,8 +241,11 @@ impl Bird {
 
 impl Agent for Bird {
     fn step(&mut self) {
-
-        let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(self.pos, 10.0);
+        let vec = GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .get_neighbors_within_distance(self.pos, 10.0);
 
         let avoid = self.avoidance(&vec);
         let cohe = self.cohesion(&vec);
@@ -233,23 +253,34 @@ impl Agent for Bird {
         let cons = self.consistency(&vec);
         let mom = self.last_d;
 
-        let mut dx = COHESION*cohe.x + AVOIDANCE*avoid.x + CONSISTENCY*cons.x + RANDOMNESS*rand.x + MOMENTUM*mom.x;
-        let mut dy = COHESION*cohe.y + AVOIDANCE*avoid.y + CONSISTENCY*cons.y + RANDOMNESS*rand.y + MOMENTUM*mom.y;
+        let mut dx = COHESION * cohe.x
+            + AVOIDANCE * avoid.x
+            + CONSISTENCY * cons.x
+            + RANDOMNESS * rand.x
+            + MOMENTUM * mom.x;
+        let mut dy = COHESION * cohe.y
+            + AVOIDANCE * avoid.y
+            + CONSISTENCY * cons.y
+            + RANDOMNESS * rand.y
+            + MOMENTUM * mom.y;
 
-        let dis = (dx*dx + dy*dy).sqrt();
+        let dis = (dx * dx + dy * dy).sqrt();
         if dis > 0.0 {
-            dx = dx/dis*JUMP;
-            dy = dy/dis*JUMP;
+            dx = dx / dis * JUMP;
+            dy = dy / dis * JUMP;
         }
 
-        let _lastd = Real2D {x: dx, y:dy};
+        let _lastd = Real2D { x: dx, y: dy };
         let loc_x = toroidal_transform(self.pos.x + dx, WIDTH);
         let loc_y = toroidal_transform(self.pos.y + dy, WIDTH);
 
-        self.pos = Real2D{x: loc_x, y: loc_y};
+        self.pos = Real2D { x: loc_x, y: loc_y };
 
-        GLOBAL_STATE.lock().unwrap().field1.set_object_location(*self, Real2D{x: loc_x, y: loc_y});
-
+        GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(*self, Real2D { x: loc_x, y: loc_y });
     }
 }
 
@@ -259,8 +290,8 @@ impl Hash for Bird {
         H: Hasher,
     {
         self.id.hash(state);
-    //    state.write_u128(self.id);
-    //    state.finish();
+        //    state.write_u128(self.id);
+        //    state.finish();
     }
 }
 
@@ -272,7 +303,7 @@ impl PartialEq for Bird {
     }
 }
 
-impl Location2D for Bird {
+impl Location2D<Real2D> for Bird {
     fn get_location(self) -> Real2D {
         self.pos
     }

--- a/examples/boids.rs
+++ b/examples/boids.rs
@@ -1,43 +1,42 @@
 extern crate abm;
-extern crate priority_queue;
 extern crate piston_window;
+extern crate priority_queue;
 
 #[macro_use]
 extern crate lazy_static;
 
-use abm::field2D::toroidal_transform;
-use abm::field2D::toroidal_distance;
-use rand::Rng;
-use std::hash::Hasher;
-use std::hash::Hash;
-use std::fmt;
 use abm::agent::Agent;
-use abm::schedule::Schedule;
-use std::time::{Instant};
-use abm::location::Real2D;
+use abm::field_2d::toroidal_distance;
+use abm::field_2d::toroidal_transform;
+use abm::field_2d::Field2D;
 use abm::location::Location2D;
-use abm::field2D::Field2D;
+use abm::location::Real2D;
+use abm::schedule::Schedule;
+use rand::Rng;
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::time::Instant;
 
 use std::sync::Mutex;
 
 static mut _COUNT: u128 = 0;
 static STEP: u128 = 50;
 static NUM_AGENT: u128 = 8400;
-static WIDTH: f64 =200.0;
+static WIDTH: f64 = 200.0;
 static HEIGTH: f64 = 200.0;
-static DISCRETIZATION: f64 = 10.0/1.5;
+static DISCRETIZATION: f64 = 10.0 / 1.5;
 static TOROIDAL: bool = true;
-static COHESION : f64 = 1.0;
-static AVOIDANCE : f64 = 1.0;
-static RANDOMNESS : f64 = 1.0;
-static CONSISTENCY : f64 = 1.0;
-static MOMENTUM : f64 = 1.0;
-static JUMP : f64 = 0.7;
-
-
+static COHESION: f64 = 1.0;
+static AVOIDANCE: f64 = 1.0;
+static RANDOMNESS: f64 = 1.0;
+static CONSISTENCY: f64 = 1.0;
+static MOMENTUM: f64 = 1.0;
+static JUMP: f64 = 0.7;
 
 lazy_static! {
-    static  ref GLOBAL_STATE: Mutex<State> = Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
+    static ref GLOBAL_STATE: Mutex<State> =
+        Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
 }
 
 fn main() {
@@ -45,13 +44,23 @@ fn main() {
     let mut schedule: Schedule<Bird> = Schedule::new();
     assert!(schedule.events.is_empty());
 
-    for bird_id in 0..NUM_AGENT{
-
+    for bird_id in 0..NUM_AGENT {
         let r1: f64 = rng.gen();
         let r2: f64 = rng.gen();
-        let last_d = Real2D {x: 0.0, y: 0.0};
-        let bird = Bird::new(bird_id, Real2D{x: WIDTH*r1, y: HEIGTH*r2}, last_d);
-        GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird, bird.pos);
+        let last_d = Real2D { x: 0.0, y: 0.0 };
+        let bird = Bird::new(
+            bird_id,
+            Real2D {
+                x: WIDTH * r1,
+                y: HEIGTH * r2,
+            },
+            last_d,
+        );
+        GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(bird, bird.pos);
         schedule.schedule_repeating(bird, 0.0, 0);
     }
 
@@ -59,19 +68,21 @@ fn main() {
 
     let start = Instant::now();
 
-    for _ in 1..STEP{
-	println!("step");
+    for _ in 1..STEP {
+        println!("step");
         schedule.step();
     }
-
 
     let duration = start.elapsed();
 
     println!("Time elapsed in testing schedule is: {:?}", duration);
-    println!("Step for seconds: {:?}", STEP as f64/(duration.as_secs() as f64));
+    println!(
+        "Step for seconds: {:?}",
+        STEP as f64 / (duration.as_secs() as f64)
+    );
 }
 
-pub struct State{
+pub struct State {
     pub field1: Field2D<Bird>,
 }
 
@@ -84,7 +95,7 @@ impl State {
 }
 
 #[derive(Clone, Copy)]
-pub struct Bird{
+pub struct Bird {
     pub id: u128,
     pub pos: Real2D,
     pub last_d: Real2D,
@@ -92,16 +103,12 @@ pub struct Bird{
 
 impl Bird {
     pub fn new(id: u128, pos: Real2D, last_d: Real2D) -> Self {
-        Bird {
-            id,
-            pos,
-            last_d,
-        }
+        Bird { id, pos, last_d }
     }
 
-    pub fn avoidance (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn avoidance(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -114,26 +121,32 @@ impl Bird {
             if self != vec[i] {
                 let dx = toroidal_distance(self.pos.x, vec[i].pos.x, WIDTH);
                 let dy = toroidal_distance(self.pos.y, vec[i].pos.y, HEIGTH);
-                let square = (dx*dx + dy*dy).sqrt();
+                let square = (dx * dx + dy * dy).sqrt();
                 count += 1;
-                x += dx/(square*square) + 1.0;
-                y += dy/(square*square) + 1.0;
+                x += dx / (square * square) + 1.0;
+                y += dy / (square * square) + 1.0;
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         } else {
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         }
     }
 
-    pub fn cohesion (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn cohesion(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -152,12 +165,18 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         } else {
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         }
     }
@@ -165,21 +184,21 @@ impl Bird {
     pub fn randomness(self) -> Real2D {
         let mut rng = rand::thread_rng();
         let r1: f64 = rng.gen();
-        let x = r1*2.0 -1.0;
+        let x = r1 * 2.0 - 1.0;
         let r2: f64 = rng.gen();
-        let y = r2*2.0 -1.0;
+        let y = r2 * 2.0 - 1.0;
 
-        let square = (x*x + y*y).sqrt();
+        let square = (x * x + y * y).sqrt();
         let real = Real2D {
-            x: 0.05*x/square,
-            y: 0.05*y/square,
+            x: 0.05 * x / square,
+            y: 0.05 * y / square,
         };
         return real;
     }
 
-    pub fn consistency (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn consistency(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -198,12 +217,15 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/count as f64, y: y/count as f64};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / count as f64,
+                y: y / count as f64,
+            };
             return real;
         } else {
-            let real = Real2D {x: x, y: y};
+            let real = Real2D { x: x, y: y };
             return real;
         }
     }
@@ -211,8 +233,11 @@ impl Bird {
 
 impl Agent for Bird {
     fn step(&mut self) {
-
-        let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(self.pos, 10.0);
+        let vec = GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .get_neighbors_within_distance(self.pos, 10.0);
 
         let avoid = self.avoidance(&vec);
         let cohe = self.cohesion(&vec);
@@ -220,23 +245,34 @@ impl Agent for Bird {
         let cons = self.consistency(&vec);
         let mom = self.last_d;
 
-        let mut dx = COHESION*cohe.x + AVOIDANCE*avoid.x + CONSISTENCY*cons.x + RANDOMNESS*rand.x + MOMENTUM*mom.x;
-        let mut dy = COHESION*cohe.y + AVOIDANCE*avoid.y + CONSISTENCY*cons.y + RANDOMNESS*rand.y + MOMENTUM*mom.y;
+        let mut dx = COHESION * cohe.x
+            + AVOIDANCE * avoid.x
+            + CONSISTENCY * cons.x
+            + RANDOMNESS * rand.x
+            + MOMENTUM * mom.x;
+        let mut dy = COHESION * cohe.y
+            + AVOIDANCE * avoid.y
+            + CONSISTENCY * cons.y
+            + RANDOMNESS * rand.y
+            + MOMENTUM * mom.y;
 
-        let dis = (dx*dx + dy*dy).sqrt();
+        let dis = (dx * dx + dy * dy).sqrt();
         if dis > 0.0 {
-            dx = dx/dis*JUMP;
-            dy = dy/dis*JUMP;
+            dx = dx / dis * JUMP;
+            dy = dy / dis * JUMP;
         }
 
-        let _lastd = Real2D {x: dx, y:dy};
+        let _lastd = Real2D { x: dx, y: dy };
         let loc_x = toroidal_transform(self.pos.x + dx, WIDTH);
         let loc_y = toroidal_transform(self.pos.y + dy, WIDTH);
 
-        self.pos = Real2D{x: loc_x, y: loc_y};
+        self.pos = Real2D { x: loc_x, y: loc_y };
 
-        GLOBAL_STATE.lock().unwrap().field1.set_object_location(*self, Real2D{x: loc_x, y: loc_y});
-
+        GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(*self, Real2D { x: loc_x, y: loc_y });
     }
 }
 
@@ -246,8 +282,8 @@ impl Hash for Bird {
         H: Hasher,
     {
         self.id.hash(state);
-    //    state.write_u128(self.id);
-    //    state.finish();
+        //    state.write_u128(self.id);
+        //    state.finish();
     }
 }
 
@@ -259,7 +295,7 @@ impl PartialEq for Bird {
     }
 }
 
-impl Location2D for Bird {
+impl Location2D<Real2D> for Bird {
     fn get_location(self) -> Real2D {
         self.pos
     }
@@ -271,6 +307,6 @@ impl Location2D for Bird {
 
 impl fmt::Display for Bird {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-       write!(f, "{}", self.id)
+        write!(f, "{}", self.id)
     }
 }

--- a/examples/boids_test.rs
+++ b/examples/boids_test.rs
@@ -4,68 +4,78 @@ extern crate priority_queue;
 #[macro_use]
 extern crate lazy_static;
 
-use abm::field2D::toroidal_transform;
-use abm::field2D::toroidal_distance;
-use rand::Rng;
-use std::hash::Hasher;
-use std::hash::Hash;
-use std::fmt;
 use abm::agent::Agent;
-use abm::schedule::Schedule;
-use std::time::{Instant};
-use abm::location::Real2D;
+use abm::field_2d::toroidal_distance;
+use abm::field_2d::toroidal_transform;
+use abm::field_2d::Field2D;
 use abm::location::Location2D;
-use abm::field2D::Field2D;
+use abm::location::Real2D;
+use abm::schedule::Schedule;
+use rand::Rng;
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::Mutex;
+use std::time::Instant;
 
 static mut _COUNT: u128 = 0;
 static STEP: u128 = 150;
 static WIDTH: f64 = 150.0;
 static HEIGTH: f64 = 150.0;
-static DISCRETIZATION: f64 = 10.0/1.5;
+static DISCRETIZATION: f64 = 10.0 / 1.5;
 static TOROIDAL: bool = true;
-static COHESION : f64 = 1.0;
-static AVOIDANCE : f64 = 1.0;
-static RANDOMNESS : f64 = 1.0;
-static CONSISTENCY : f64 = 1.0;
-static MOMENTUM : f64 = 1.0;
-static JUMP : f64 = 0.7;
+static COHESION: f64 = 1.0;
+static AVOIDANCE: f64 = 1.0;
+static RANDOMNESS: f64 = 1.0;
+static CONSISTENCY: f64 = 1.0;
+static MOMENTUM: f64 = 1.0;
+static JUMP: f64 = 0.7;
 
 lazy_static! {
-    static  ref GLOBAL_STATE: Mutex<State> = Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
+    static ref GLOBAL_STATE: Mutex<State> =
+        Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
 }
 
 fn main() {
     let mut schedule: Schedule<Bird> = Schedule::new();
     assert!(schedule.events.is_empty());
 
-
-    let last_d = Real2D {x: 0.0, y: 0.0};
-    let bird = Bird::new(0, Real2D{x: 0.0 ,y: 0.0}, last_d);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird, bird.pos);
+    let last_d = Real2D { x: 0.0, y: 0.0 };
+    let bird = Bird::new(0, Real2D { x: 0.0, y: 0.0 }, last_d);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird, bird.pos);
     schedule.schedule_repeating(bird, 0.0, 0);
 
-    let last_d = Real2D {x: 0.0, y: 0.0};
-    let bird = Bird::new(1, Real2D{x: 0.1 ,y: 0.1}, last_d);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird, bird.pos);
+    let last_d = Real2D { x: 0.0, y: 0.0 };
+    let bird = Bird::new(1, Real2D { x: 0.1, y: 0.1 }, last_d);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird, bird.pos);
     schedule.schedule_repeating(bird, 0.0, 0);
 
     assert!(!schedule.events.is_empty());
 
     let start = Instant::now();
 
-    for _ in 1..STEP{
+    for _ in 1..STEP {
         schedule.step();
     }
-
 
     let duration = start.elapsed();
 
     println!("Time elapsed in testing schedule is: {:?}", duration);
-    println!("Step for seconds: {:?}", STEP as f64/(duration.as_secs() as f64));
+    println!(
+        "Step for seconds: {:?}",
+        STEP as f64 / (duration.as_secs() as f64)
+    );
 }
 
-pub struct State{
+pub struct State {
     pub field1: Field2D<Bird>,
 }
 
@@ -78,7 +88,7 @@ impl State {
 }
 
 #[derive(Clone, Copy)]
-pub struct Bird{
+pub struct Bird {
     pub id: u128,
     pub pos: Real2D,
     pub last_d: Real2D,
@@ -86,16 +96,12 @@ pub struct Bird{
 
 impl Bird {
     pub fn new(id: u128, pos: Real2D, last_d: Real2D) -> Self {
-        Bird {
-            id,
-            pos,
-            last_d,
-        }
+        Bird { id, pos, last_d }
     }
 
-    pub fn avoidance (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn avoidance(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -108,26 +114,32 @@ impl Bird {
             if self != vec[i] {
                 let dx = toroidal_distance(self.pos.x, vec[i].pos.x, WIDTH);
                 let dy = toroidal_distance(self.pos.y, vec[i].pos.y, HEIGTH);
-                let square = (dx*dx + dy*dy).sqrt();
+                let square = (dx * dx + dy * dy).sqrt();
                 count += 1;
-                x += dx/(square*square) + 1.0;
-                y += dy/(square*square) + 1.0;
+                x += dx / (square * square) + 1.0;
+                y += dy / (square * square) + 1.0;
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         } else {
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         }
     }
 
-    pub fn cohesion (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn cohesion(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -147,12 +159,18 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         } else {
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         }
     }
@@ -160,21 +178,21 @@ impl Bird {
     pub fn randomness(self) -> Real2D {
         let mut rng = rand::thread_rng();
         let r1: f64 = rng.gen();
-        let x = r1*2.0 -1.0;
+        let x = r1 * 2.0 - 1.0;
         let r2: f64 = rng.gen();
-        let y = r2*2.0 -1.0;
+        let y = r2 * 2.0 - 1.0;
 
-        let square = (x*x + y*y).sqrt();
+        let square = (x * x + y * y).sqrt();
         let real = Real2D {
-            x: 0.05*x/square,
-            y: 0.05*y/square,
+            x: 0.05 * x / square,
+            y: 0.05 * y / square,
         };
         return real;
     }
 
-    pub fn consistency (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn consistency(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -195,12 +213,15 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/count as f64, y: y/count as f64};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / count as f64,
+                y: y / count as f64,
+            };
             return real;
         } else {
-            let real = Real2D {x: x, y: y};
+            let real = Real2D { x: x, y: y };
             return real;
         }
     }
@@ -208,16 +229,17 @@ impl Bird {
 
 impl Agent for Bird {
     fn step(&mut self) {
-
-        let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(self.pos, 20.0);
-    {
-        let fpos = GLOBAL_STATE.lock().unwrap();
-        let fpos = fpos.field1.get_object_location(*self);
-        let fpos = fpos.unwrap();
-        println!("{} {} {} {}", self.id, self.pos,fpos,vec.len());
-
-    }
-
+        let vec = GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .get_neighbors_within_distance(self.pos, 20.0);
+        {
+            let fpos = GLOBAL_STATE.lock().unwrap();
+            let fpos = fpos.field1.get_object_location(*self);
+            let fpos = fpos.unwrap();
+            println!("{} {} {} {}", self.id, self.pos, fpos, vec.len());
+        }
 
         let avoid = self.avoidance(&vec);
         let cohe = self.cohesion(&vec);
@@ -225,24 +247,34 @@ impl Agent for Bird {
         let cons = self.consistency(&vec);
         let mom = self.last_d;
 
-        let mut dx = COHESION*cohe.x + AVOIDANCE*avoid.x + CONSISTENCY*cons.x + RANDOMNESS*rand.x + MOMENTUM*mom.x;
-        let mut dy = COHESION*cohe.y + AVOIDANCE*avoid.y + CONSISTENCY*cons.y + RANDOMNESS*rand.y + MOMENTUM*mom.y;
+        let mut dx = COHESION * cohe.x
+            + AVOIDANCE * avoid.x
+            + CONSISTENCY * cons.x
+            + RANDOMNESS * rand.x
+            + MOMENTUM * mom.x;
+        let mut dy = COHESION * cohe.y
+            + AVOIDANCE * avoid.y
+            + CONSISTENCY * cons.y
+            + RANDOMNESS * rand.y
+            + MOMENTUM * mom.y;
 
-        let dis = (dx*dx + dy*dy).sqrt();
+        let dis = (dx * dx + dy * dy).sqrt();
         if dis > 0.0 {
-            dx = dx/dis*JUMP;
-            dy = dy/dis*JUMP;
-
+            dx = dx / dis * JUMP;
+            dy = dy / dis * JUMP;
         }
 
-        let _lastd = Real2D {x: dx, y:dy};
+        let _lastd = Real2D { x: dx, y: dy };
         let loc_x = toroidal_transform(self.pos.x + 1.0, WIDTH);
         let loc_y = toroidal_transform(self.pos.y + 1.0, WIDTH);
 
-        self.pos = Real2D{x: loc_x, y: loc_y};
+        self.pos = Real2D { x: loc_x, y: loc_y };
 
-        GLOBAL_STATE.lock().unwrap().field1.set_object_location(*self, Real2D{x: loc_x, y: loc_y});
-
+        GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(*self, Real2D { x: loc_x, y: loc_y });
     }
 }
 
@@ -264,7 +296,7 @@ impl PartialEq for Bird {
     }
 }
 
-impl Location2D for Bird {
+impl Location2D<Real2D> for Bird {
     fn get_location(self) -> Real2D {
         self.pos
     }

--- a/src/agentimpl.rs
+++ b/src/agentimpl.rs
@@ -1,8 +1,8 @@
+use crate::agent::Agent;
+use std::clone::Clone;
+use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
-use crate::agent::Agent;
-use std::fmt;
-use std::clone::Clone;
 
 static mut COUNTER: u32 = 0;
 
@@ -13,17 +13,17 @@ pub struct AgentImpl<A: Agent + Clone> {
     pub repeating: bool,
 }
 
-impl< A: Agent + Clone> AgentImpl< A> {
-    pub fn new(the_agent: A) -> AgentImpl<A>{
+impl<A: Agent + Clone> AgentImpl<A> {
+    pub fn new(the_agent: A) -> AgentImpl<A> {
         unsafe {
             COUNTER += 1;
 
             AgentImpl {
-                    id: COUNTER,
-                    agent: the_agent,
-                    repeating: false,
-                }
+                id: COUNTER,
+                agent: the_agent,
+                repeating: false,
             }
+        }
     }
 
     pub fn step(&mut self) {
@@ -47,7 +47,7 @@ impl<A: Agent + Clone> PartialEq for AgentImpl<A> {
     }
 }
 
-impl< A: Agent + Clone> Hash for AgentImpl<A> {
+impl<A: Agent + Clone> Hash for AgentImpl<A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id.hash(state);
     }

--- a/src/grid_2d.rs
+++ b/src/grid_2d.rs
@@ -1,0 +1,31 @@
+use std::hash::Hash;
+
+use crate::location::Int2D;
+use hashbrown::HashMap;
+
+// A crude implementation of a grid, with agents as keys and their locations as values.
+pub struct Grid2D<A: Eq + Hash + Clone + Copy> {
+    pub locs: HashMap<A, Int2D>,
+    pub width: i64,
+    pub height: i64,
+}
+
+impl<A: Eq + Hash + Clone + Copy> Grid2D<A> {
+    pub fn new(width: i64, height: i64) -> Grid2D<A> {
+        Grid2D {
+            locs: HashMap::with_capacity((width * height) as usize),
+            width,
+            height,
+        }
+    }
+
+    pub fn set_object_location(&mut self, agent: &mut A, new_pos: Int2D) {
+        let mut agent_loc = self.locs.entry(*agent).or_insert(new_pos);
+        agent_loc.x = new_pos.x;
+        agent_loc.y = new_pos.y;
+    }
+
+    pub fn get_object_location(&self, agent: &A) -> Option<&Int2D> {
+        self.locs.get(agent)
+    }
+}

--- a/src/grid_2d.rs
+++ b/src/grid_2d.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use crate::location::Int2D;
 use hashbrown::HashMap;
 
-// A crude implementation of a grid, with agents as keys and their locations as values.
+/// A crude implementation of a grid that wraps a HashMap, with agents as keys and their locations as values.
 pub struct Grid2D<A: Eq + Hash + Clone + Copy> {
     pub locs: HashMap<A, Int2D>,
     pub width: i64,
@@ -11,6 +11,7 @@ pub struct Grid2D<A: Eq + Hash + Clone + Copy> {
 }
 
 impl<A: Eq + Hash + Clone + Copy> Grid2D<A> {
+    /// Initializes a Grid2D with a specied capacity of width * height.
     pub fn new(width: i64, height: i64) -> Grid2D<A> {
         Grid2D {
             locs: HashMap::with_capacity((width * height) as usize),
@@ -19,12 +20,52 @@ impl<A: Eq + Hash + Clone + Copy> Grid2D<A> {
         }
     }
 
-    pub fn set_object_location(&mut self, agent: &mut A, new_pos: Int2D) {
-        let mut agent_loc = self.locs.entry(*agent).or_insert(new_pos);
+    /// Inserts the agent in the grid, with the agent itself as key and its position as value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use abm::agent::Agent;
+    /// use abm::grid_2d::Grid2D;
+    /// use abm::location::Int2D;
+    /// #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+    /// struct A {};
+    /// impl Agent for A {fn step(&mut self) {
+    ///         println!("Stepping!");
+    ///     }
+    /// }
+    /// let mut grid = Grid2D::new(10,10);
+    /// let mut agent = A{};
+    /// let loc = Int2D{x: 2, y: 2};
+    /// grid.set_object_location(&mut agent, &loc);
+    /// assert!(grid.get_object_location(&agent) == Some(&loc));
+    /// ```
+    pub fn set_object_location(&mut self, agent: &mut A, new_pos: &Int2D) {
+        let mut agent_loc = self.locs.entry(*agent).or_insert(*new_pos);
         agent_loc.x = new_pos.x;
         agent_loc.y = new_pos.y;
     }
 
+    /// Fetches the position of the agent in the grid.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use abm::agent::Agent;
+    /// use abm::grid_2d::Grid2D;
+    /// use abm::location::Int2D;
+    /// #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+    /// struct A {};
+    /// impl Agent for A {fn step(&mut self) {
+    ///         println!("Stepping!");
+    ///     }
+    /// }
+    /// let mut grid = Grid2D::new(10,10);
+    /// let mut agent = A{};
+    /// let loc = Int2D{x: 2, y: 2};
+    /// grid.set_object_location(&mut agent, &loc);
+    /// assert!(grid.get_object_location(&agent) == Some(&loc));
+    /// ```
     pub fn get_object_location(&self, agent: &A) -> Option<&Int2D> {
         self.locs.get(agent)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
-pub mod priority;
 pub mod agent;
-pub mod schedule;
 pub mod agentimpl;
-pub mod field2D;
+pub mod field_2d;
+pub mod grid_2d;
 pub mod location;
+pub mod priority;
+pub mod schedule;
+pub mod simple_grid_2d;

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,10 +1,17 @@
 use std::fmt;
 
+/// A trait specifying the position of a struct.
+///
+/// # Safety
+///
+/// The generic type T bounds are lax, they can support types different than Real2D and Int2D,
+/// but it has been tested properly only with those two.
 pub trait Location2D<T: fmt::Display + Eq + PartialEq + Copy> {
     fn get_location(self) -> T;
     fn set_location(&mut self, loc: T);
 }
 
+/// A structure describing a two-dimensional, f64 position, for use in continuous fields.
 #[derive(Clone, Default, Debug, Copy)]
 pub struct Real2D {
     pub x: f64,
@@ -25,6 +32,7 @@ impl PartialEq for Real2D {
     }
 }
 
+/// A structure describing a two-dimensional, i64 position, for use in discrete fields such as a grid.
 #[derive(Clone, Hash, Copy)]
 pub struct Int2D {
     pub x: i64,

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-pub trait Location2D {
-    fn get_location(self) -> Real2D;
-    fn set_location(&mut self, loc: Real2D);
+pub trait Location2D<T: fmt::Display + Eq + PartialEq + Copy> {
+    fn get_location(self) -> T;
+    fn set_location(&mut self, loc: T);
 }
 
 #[derive(Clone, Default, Debug, Copy)]
@@ -29,6 +29,12 @@ impl PartialEq for Real2D {
 pub struct Int2D {
     pub x: i64,
     pub y: i64,
+}
+
+impl fmt::Display for Int2D {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.x, self.y)
+    }
 }
 
 impl Eq for Int2D {}

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -1,40 +1,49 @@
-use std::cmp::Ordering;
 use std::cmp::Eq;
+use std::cmp::Ordering;
 use std::fmt;
 
 #[derive(Clone, Debug)]
-pub struct Priority{
-    pub time:f64,
-    pub ordering:i64
+pub struct Priority {
+    pub time: f64,
+    pub ordering: i64,
 }
 
 impl Priority {
     pub fn new(the_time: f64, the_ordering: i64) -> Priority {
         Priority {
             time: the_time,
-            ordering: the_ordering
+            ordering: the_ordering,
         }
     }
 }
 
 impl Ord for Priority {
     fn cmp(&self, other: &Priority) -> Ordering {
+        if self.time < other.time {
+            return Ordering::Greater;
+        }
+        if self.time > other.time {
+            return Ordering::Less;
+        }
 
-        if self.time < other.time {return Ordering::Greater;}
-        if self.time > other.time {return Ordering::Less;}
-
-        if self.ordering < other.ordering {return Ordering::Greater;}
-        if self.ordering > other.ordering {return Ordering::Less;}
+        if self.ordering < other.ordering {
+            return Ordering::Greater;
+        }
+        if self.ordering > other.ordering {
+            return Ordering::Less;
+        }
         //return self.time.cmp(&other.time)
 
         Ordering::Equal
     }
 }
+
 impl PartialOrd for Priority {
     fn partial_cmp(&self, other: &Priority) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
+
 impl Eq for Priority {}
 
 impl PartialEq for Priority {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,14 +1,14 @@
 extern crate priority_queue;
 
-use priority_queue::PriorityQueue;
-use crate::priority::Priority;
 use crate::agent::Agent;
 use crate::agentimpl::AgentImpl;
+use crate::priority::Priority;
+use priority_queue::PriorityQueue;
 
-pub struct Schedule<A:'static + Agent + Clone + Send>{
+pub struct Schedule<A: 'static + Agent + Clone + Send> {
     pub step: usize,
     pub time: f64,
-    pub events: PriorityQueue<AgentImpl<A>,Priority>,
+    pub events: PriorityQueue<AgentImpl<A>, Priority>,
 }
 
 #[derive(Clone)]
@@ -21,13 +21,12 @@ impl<A: 'static + Agent + Clone> Pair<A> {
     fn new(agent: AgentImpl<A>, the_priority: Priority) -> Pair<A> {
         Pair {
             agentimpl: agent,
-            priority: the_priority
+            priority: the_priority,
         }
     }
 }
 
-impl<A: 'static +  Agent + Clone + Send> Schedule<A> {
-
+impl<A: 'static + Agent + Clone + Send> Schedule<A> {
     pub fn new() -> Schedule<A> {
         Schedule {
             step: 0,
@@ -36,34 +35,39 @@ impl<A: 'static +  Agent + Clone + Send> Schedule<A> {
         }
     }
 
-    pub fn schedule_once(&mut self, agent: AgentImpl<A>,the_time:f64, the_ordering:i64) {
-        self.events.push(agent, Priority{time: the_time, ordering: the_ordering});
+    pub fn schedule_once(&mut self, agent: AgentImpl<A>, the_time: f64, the_ordering: i64) {
+        self.events.push(
+            agent,
+            Priority {
+                time: the_time,
+                ordering: the_ordering,
+            },
+        );
     }
 
-    pub fn schedule_repeating(&mut self, agent: A, the_time:f64, the_ordering:i64) {
+    pub fn schedule_repeating(&mut self, agent: A, the_time: f64, the_ordering: i64) {
         let mut a = AgentImpl::new(agent);
         a.repeating = true;
         let pr = Priority::new(the_time, the_ordering);
         self.events.push(a, pr);
     }
 
-    pub fn step(&mut self){
+    pub fn step(&mut self) {
         self.step += 1;
 
         let events = &mut self.events;
         if events.is_empty() {
             println!("coda eventi vuota");
-            return
+            return;
         }
 
         let mut cevents: Vec<Pair<A>> = Vec::new();
-
 
         match events.peek() {
             Some(item) => {
                 let (_agent, priority) = item;
                 self.time = priority.time;
-            },
+            }
             None => panic!("agente non trovato"),
         }
 
@@ -78,7 +82,7 @@ impl<A: 'static +  Agent + Clone + Send> Schedule<A> {
                     if priority.time > self.time {
                         break;
                     }
-                },
+                }
                 None => panic!("agente non trovato"),
             }
 
@@ -89,20 +93,20 @@ impl<A: 'static +  Agent + Clone + Send> Schedule<A> {
                     // let x = agent.id.clone();
                     // println!("{}", x);
                     cevents.push(Pair::new(agent, priority));
-                },
+                }
                 None => panic!("no item"),
             }
         }
         //println!("STEP,{},SCHEDULE,{}", self.step,cevents.len());
         for mut item in cevents.into_iter() {
-
-                 item.agentimpl.step();
-                 if item.agentimpl.repeating {
-                     self.schedule_once(item.agentimpl, item.priority.time + 1.0, item.priority.ordering);
-                 }
-
+            item.agentimpl.step();
+            if item.agentimpl.repeating {
+                self.schedule_once(
+                    item.agentimpl,
+                    item.priority.time + 1.0,
+                    item.priority.ordering,
+                );
+            }
         }
-
     }
-
 }

--- a/src/simple_grid_2d.rs
+++ b/src/simple_grid_2d.rs
@@ -1,6 +1,6 @@
 use crate::location::Int2D;
 
-// A crude implementation of a matrix based grid, for easy access of specific positions.
+/// A crude implementation of a matrix based grid, for quick access of specific positions.
 pub struct SimpleGrid2D<T: Copy + Clone> {
     pub locs: Vec<Vec<Option<T>>>,
     pub width: i64,
@@ -8,6 +8,7 @@ pub struct SimpleGrid2D<T: Copy + Clone> {
 }
 
 impl<T: Copy + Clone> SimpleGrid2D<T> {
+    /// Initializes a SimpleGrid2D that wraps a width * height matrix, with values of type Option<T>.
     pub fn new(width: i64, height: i64) -> SimpleGrid2D<T> {
         SimpleGrid2D {
             locs: vec![vec![None; height as usize]; width as usize],
@@ -16,16 +17,66 @@ impl<T: Copy + Clone> SimpleGrid2D<T> {
         }
     }
 
+    /// Fetches the value contained within a cell of the matrix.
+    ///
+    /// None if the cell's empty, Some(T) otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use abm::simple_grid_2d::SimpleGrid2D;
+    /// # use abm::location::Int2D;
+    ///
+    /// let mut simple_grid = SimpleGrid2D::new(10, 10);
+    /// let value = 5;
+    /// let loc = Int2D{x: 2, y: 2};
+    /// simple_grid.set_value_at_pos(&loc, value);
+    /// let cell_value = simple_grid.get_value_at_pos(&loc);
+    /// assert_eq!(cell_value, Some(5));
+    /// ```
     pub fn get_value_at_pos(&self, pos: &Int2D) -> Option<T> {
         return self.locs[pos.x as usize][pos.y as usize];
     }
 
+    /// Sets the value of a matrix's cell to a copy of T.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use abm::simple_grid_2d::SimpleGrid2D;
+    /// # use abm::location::Int2D;
+    ///
+    /// let mut simple_grid = SimpleGrid2D::new(10, 10);
+    /// let value = 5;
+    /// let loc = Int2D{x: 2, y: 2};
+    /// simple_grid.set_value_at_pos(&loc, value);
+    /// let cell_value = simple_grid.get_value_at_pos(&loc);
+    /// assert_eq!(cell_value, Some(5));
+    /// ```
     pub fn set_value_at_pos(&mut self, pos: &Int2D, value: T) {
         self.locs[pos.x as usize][pos.y as usize] = Some(value);
     }
 }
 
 impl<T: Copy + Clone + PartialOrd> SimpleGrid2D<T> {
+    /// Returns a copy of the minimum T value, wrapped in an Option, contained within the matrix.
+    ///
+    /// Returns None if the matrix is empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use abm::simple_grid_2d::SimpleGrid2D;
+    /// # use abm::location::Int2D;
+    ///
+    /// let mut simple_grid = SimpleGrid2D::new(10, 10);
+    /// for x in 0..10 {
+    ///     for y in 0..10 {
+    ///         simple_grid.set_value_at_pos(&Int2D{x, y}, x+y);
+    ///     }
+    /// }
+    /// assert_eq!(simple_grid.min(), Some(0));
+    /// ```
     pub fn min(&self) -> Option<T> {
         let mut min: Option<T> = None;
         for i in self.locs.iter() {
@@ -44,6 +95,24 @@ impl<T: Copy + Clone + PartialOrd> SimpleGrid2D<T> {
         min
     }
 
+    /// Returns a copy of the maximum T value, wrapped in an Option, contained within the matrix.
+    ///
+    /// Returns None if the matrix is empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use abm::simple_grid_2d::SimpleGrid2D;
+    /// # use abm::location::Int2D;
+    ///
+    /// let mut simple_grid = SimpleGrid2D::new(10, 10);
+    /// for x in 0..10 {
+    ///     for y in 0..10 {
+    ///         simple_grid.set_value_at_pos(&Int2D{x, y}, x+y);
+    ///     }
+    /// }
+    /// assert_eq!(simple_grid.max(), Some(18));
+    /// ```
     pub fn max(&self) -> Option<T> {
         let mut max: Option<T> = None;
         for i in self.locs.iter() {

--- a/src/simple_grid_2d.rs
+++ b/src/simple_grid_2d.rs
@@ -1,0 +1,83 @@
+use crate::location::Int2D;
+
+// A crude implementation of a matrix based grid, for easy access of specific positions.
+pub struct SimpleGrid2D<T: Copy + Clone> {
+    pub locs: Vec<Vec<Option<T>>>,
+    pub width: i64,
+    pub height: i64,
+}
+
+impl<T: Copy + Clone> SimpleGrid2D<T> {
+    pub fn new(width: i64, height: i64) -> SimpleGrid2D<T> {
+        SimpleGrid2D {
+            locs: vec![vec![None; height as usize]; width as usize],
+            width,
+            height,
+        }
+    }
+
+    pub fn get_value_at_pos(&self, pos: &Int2D) -> Option<T> {
+        return self.locs[pos.x as usize][pos.y as usize];
+    }
+
+    pub fn set_value_at_pos(&mut self, pos: &Int2D, value: T) {
+        self.locs[pos.x as usize][pos.y as usize] = Some(value);
+    }
+}
+
+impl<T: Copy + Clone + PartialOrd> SimpleGrid2D<T> {
+    pub fn min(&self) -> Option<T> {
+        let mut min: Option<T> = None;
+        for i in self.locs.iter() {
+            for j in i.iter() {
+                if let Some(pos) = j {
+                    if let Some(actual_min) = min {
+                        if *pos < actual_min {
+                            min = Some(*pos);
+                        }
+                    } else {
+                        min = Some(*pos);
+                    }
+                }
+            }
+        }
+        min
+    }
+
+    pub fn max(&self) -> Option<T> {
+        let mut max: Option<T> = None;
+        for i in self.locs.iter() {
+            for j in i.iter() {
+                if let Some(pos) = j {
+                    if let Some(actual_min) = max {
+                        if *pos > actual_min {
+                            max = Some(*pos);
+                        }
+                    } else {
+                        max = Some(*pos);
+                    }
+                }
+            }
+        }
+        max
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::location::Int2D;
+    use crate::simple_grid_2d::SimpleGrid2D;
+
+    #[test]
+    fn simple_grid_2d() {
+        let mut grid = SimpleGrid2D::<i64>::new(10, 10);
+        let pos = Int2D { x: 2, y: 3 };
+        let pos2 = Int2D { x: 4, y: 5 };
+        grid.set_value_at_pos(&pos, 5);
+        grid.set_value_at_pos(&pos2, 10);
+        let val = grid.get_value_at_pos(&pos);
+        assert_eq!(val, Some(5));
+        assert_eq!(grid.min(), Some(5));
+        assert_eq!(grid.max(), Some(10));
+    }
+}

--- a/tests/field2d.rs
+++ b/tests/field2d.rs
@@ -4,18 +4,19 @@ extern crate priority_queue;
 #[macro_use]
 extern crate lazy_static;
 
-use std::sync::Mutex;
-use abm::field2D::toroidal_transform;
-use abm::field2D::toroidal_distance;
-use rand::Rng;
-use std::hash::Hasher;
-use std::hash::Hash;
-use std::fmt;
 use abm::agent::Agent;
+use abm::field_2d::toroidal_distance;
+use abm::field_2d::toroidal_transform;
+use rand::Rng;
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::Mutex;
 //use abm::schedule::Schedule;
-use abm::location::Real2D;
+use abm::field_2d::Field2D;
 use abm::location::Location2D;
-use abm::field2D::Field2D;
+use abm::location::Real2D;
+
 static mut _COUNT: u128 = 0;
 static _STEP: u128 = 10;
 static _NUM_AGENT: u128 = 1000;
@@ -23,45 +24,72 @@ static WIDTH: f64 = 10.0;
 static HEIGTH: f64 = 10.0;
 static DISCRETIZATION: f64 = 0.5;
 static TOROIDAL: bool = true;
-static COHESION : f64 = 1.0;
-static AVOIDANCE : f64 = 1.0;
-static RANDOMNESS : f64 = 1.0;
-static CONSISTENCY : f64 = 1.0;
-static MOMENTUM : f64 = 1.0;
-static JUMP : f64 = 0.7;
-
-
+static COHESION: f64 = 1.0;
+static AVOIDANCE: f64 = 1.0;
+static RANDOMNESS: f64 = 1.0;
+static CONSISTENCY: f64 = 1.0;
+static MOMENTUM: f64 = 1.0;
+static JUMP: f64 = 0.7;
 
 lazy_static! {
-    static ref GLOBAL_STATE: Mutex<State> = Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
+    static ref GLOBAL_STATE: Mutex<State> =
+        Mutex::new(State::new(WIDTH, HEIGTH, DISCRETIZATION, TOROIDAL));
 }
 
 lazy_static! {
-    static ref GLOBAL_STATE_2: Mutex<State> = Mutex::new(State::new(150.0, 150.0, 10.0/1.5, TOROIDAL));
+    static ref GLOBAL_STATE_2: Mutex<State> =
+        Mutex::new(State::new(150.0, 150.0, 10.0 / 1.5, TOROIDAL));
 }
 
 #[test]
 fn field_2d_test_2_1() {
+    let last_d = Real2D { x: 0.0, y: 0.0 };
 
-    let last_d = Real2D {x: 0.0, y: 0.0};
+    let bird1 = Bird::new(1, Real2D { x: 5.0, y: 5.0 }, last_d);
+    let mut bird2 = Bird::new(2, Real2D { x: 5.0, y: 6.0 }, last_d);
+    let bird3 = Bird::new(3, Real2D { x: 5.0, y: 7.0 }, last_d);
+    let bird4 = Bird::new(4, Real2D { x: 6.0, y: 6.0 }, last_d);
+    let bird5 = Bird::new(5, Real2D { x: 7.0, y: 7.0 }, last_d);
+    let mut bird6 = Bird::new(6, Real2D { x: 9.0, y: 9.0 }, last_d);
 
-    let bird1 = Bird::new(1, Real2D{x: 5.0, y: 5.0}, last_d);
-    let mut bird2 = Bird::new(2, Real2D{x: 5.0, y: 6.0}, last_d);
-    let bird3 = Bird::new(3, Real2D{x: 5.0, y: 7.0}, last_d);
-    let bird4 = Bird::new(4, Real2D{x: 6.0, y: 6.0}, last_d);
-    let bird5 = Bird::new(5, Real2D{x: 7.0, y: 7.0}, last_d);
-    let mut bird6 = Bird::new(6, Real2D{x: 9.0, y: 9.0}, last_d);
-
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird1, bird1.pos);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird2, bird2.pos);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird3, bird3.pos);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird4, bird4.pos);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird5, bird5.pos);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird6, bird6.pos);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird1, bird1.pos);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird2, bird2.pos);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird3, bird3.pos);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird4, bird4.pos);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird5, bird5.pos);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird6, bird6.pos);
 
     assert_eq!(6, GLOBAL_STATE.lock().unwrap().field1.num_objects());
 
-    let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(Real2D{x: 5.0, y: 5.0}, 5.0);
+    let vec = GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .get_neighbors_within_distance(Real2D { x: 5.0, y: 5.0 }, 5.0);
     assert_eq!(5, vec.len());
     assert!(vec.contains(&bird1));
     assert!(vec.contains(&bird2));
@@ -70,8 +98,11 @@ fn field_2d_test_2_1() {
     assert!(vec.contains(&bird5));
     assert!(!vec.contains(&bird6));
 
-
-    let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(Real2D{x: 5.0, y: 5.0}, 2.0);
+    let vec = GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .get_neighbors_within_distance(Real2D { x: 5.0, y: 5.0 }, 2.0);
 
     assert_eq!(4, vec.len());
     assert!(vec.contains(&bird1));
@@ -79,12 +110,20 @@ fn field_2d_test_2_1() {
     assert!(vec.contains(&bird3));
     assert!(vec.contains(&bird4));
 
-    let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(Real2D{x: 9.0, y: 9.0}, 1.0);
+    let vec = GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .get_neighbors_within_distance(Real2D { x: 9.0, y: 9.0 }, 1.0);
 
     assert_eq!(1, vec.len());
     assert!(vec.contains(&bird6));
 
-    let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(Real2D{x: 9.0, y: 9.0}, 5.0);
+    let vec = GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .get_neighbors_within_distance(Real2D { x: 9.0, y: 9.0 }, 5.0);
 
     assert_eq!(5, vec.len());
     assert!(vec.contains(&bird5));
@@ -93,66 +132,98 @@ fn field_2d_test_2_1() {
     assert!(vec.contains(&bird4));
     assert!(vec.contains(&bird6));
 
-        // let vec = data.field1.get_neighbors_within_distance(Real2D{x: 1.0, y: 1.0}, 5.0);
-        //
-        // assert_eq!(1, vec.len());
-        // let pos_b2 = match data.field1.get_object_location(bird2) {
-        //     Some(i) => i,
-        //     None => panic!("non trovato"),
-        // };
-        // println!("pos b2 {}", pos_b2);
+    // let vec = data.field1.get_neighbors_within_distance(Real2D{x: 1.0, y: 1.0}, 5.0);
+    //
+    // assert_eq!(1, vec.len());
+    // let pos_b2 = match data.field1.get_object_location(bird2) {
+    //     Some(i) => i,
+    //     None => panic!("non trovato"),
+    // };
+    // println!("pos b2 {}", pos_b2);
 
-    bird2.pos = Real2D {x:0.5, y:0.5};
-    bird6.pos = Real2D {x:7.5, y:7.5};
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird2, bird2.pos);
-    GLOBAL_STATE.lock().unwrap().field1.set_object_location(bird6, bird6.pos);
+    bird2.pos = Real2D { x: 0.5, y: 0.5 };
+    bird6.pos = Real2D { x: 7.5, y: 7.5 };
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird2, bird2.pos);
+    GLOBAL_STATE
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird6, bird6.pos);
     assert_eq!(6, GLOBAL_STATE.lock().unwrap().field1.num_objects());
-        // let pos_b2 = match data.field1.get_object_location(bird2) {
-        //     Some(i) => i,
-        //     None => panic!("non trovato"),
-        // };
-        // println!("pos post aggiornamento {}", pos_b2);
+    // let pos_b2 = match data.field1.get_object_location(bird2) {
+    //     Some(i) => i,
+    //     None => panic!("non trovato"),
+    // };
+    // println!("pos post aggiornamento {}", pos_b2);
 
-        // for (key, val) in data.field1.fpos.iter() {
-        //     println!("key: {} val: {}", key, val);
-        // }
-
+    // for (key, val) in data.field1.fpos.iter() {
+    //     println!("key: {} val: {}", key, val);
+    // }
 }
 
 #[test]
 fn field_2d_test_vicinato() {
+    let last_d = Real2D { x: 0.0, y: 0.0 };
 
-    let last_d = Real2D {x: 0.0, y: 0.0};
+    let mut bird1 = Bird::new(1, Real2D { x: 0.0, y: 0.0 }, last_d);
+    let mut bird2 = Bird::new(2, Real2D { x: 0.0, y: 0.0 }, last_d);
 
-    let mut bird1 = Bird::new(1, Real2D{x: 0.0, y: 0.0}, last_d);
-    let mut bird2 = Bird::new(2, Real2D{x: 0.0, y: 0.0}, last_d);
-
-
-    GLOBAL_STATE_2.lock().unwrap().field1.set_object_location(bird1, bird1.pos);
-    GLOBAL_STATE_2.lock().unwrap().field1.set_object_location(bird2, bird2.pos);
+    GLOBAL_STATE_2
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird1, bird1.pos);
+    GLOBAL_STATE_2
+        .lock()
+        .unwrap()
+        .field1
+        .set_object_location(bird2, bird2.pos);
 
     assert_eq!(2, GLOBAL_STATE_2.lock().unwrap().field1.num_objects());
 
-
-
     for i in 0..10 {
         println!("step {}", i);
-        bird1.pos = Real2D{x: bird1.pos.x + 1.0, y: bird1.pos.y + 1.0,};
-        bird2.pos = Real2D{x: bird2.pos.x + 1.0, y: bird2.pos.y + 1.0,};
+        bird1.pos = Real2D {
+            x: bird1.pos.x + 1.0,
+            y: bird1.pos.y + 1.0,
+        };
+        bird2.pos = Real2D {
+            x: bird2.pos.x + 1.0,
+            y: bird2.pos.y + 1.0,
+        };
 
-        GLOBAL_STATE_2.lock().unwrap().field1.set_object_location(bird1, bird1.pos);
-        GLOBAL_STATE_2.lock().unwrap().field1.set_object_location(bird2, bird2.pos);
+        GLOBAL_STATE_2
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(bird1, bird1.pos);
+        GLOBAL_STATE_2
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(bird2, bird2.pos);
 
-        let vec = GLOBAL_STATE_2.lock().unwrap().field1.get_neighbors_within_distance(bird1.pos, 10.0);
+        let vec = GLOBAL_STATE_2
+            .lock()
+            .unwrap()
+            .field1
+            .get_neighbors_within_distance(bird1.pos, 10.0);
         assert_eq!(2, vec.len());
         assert!(vec.contains(&bird1));
         assert!(vec.contains(&bird2));
-        let vec = GLOBAL_STATE_2.lock().unwrap().field1.get_neighbors_within_distance(bird2.pos, 10.0);
+        let vec = GLOBAL_STATE_2
+            .lock()
+            .unwrap()
+            .field1
+            .get_neighbors_within_distance(bird2.pos, 10.0);
         assert_eq!(2, vec.len());
         assert!(vec.contains(&bird1));
         assert!(vec.contains(&bird2));
     }
-
 }
 //
 // #[test]
@@ -268,8 +339,7 @@ fn field_2d_test_vicinato() {
 //     }
 // }
 
-
-pub struct State{
+pub struct State {
     pub field1: Field2D<Bird>,
 }
 
@@ -282,7 +352,7 @@ impl State {
 }
 
 #[derive(Clone, Copy)]
-pub struct Bird{
+pub struct Bird {
     pub id: u128,
     pub pos: Real2D,
     pub last_d: Real2D,
@@ -290,16 +360,12 @@ pub struct Bird{
 
 impl Bird {
     pub fn new(id: u128, pos: Real2D, last_d: Real2D) -> Self {
-        Bird {
-            id,
-            pos,
-            last_d,
-        }
+        Bird { id, pos, last_d }
     }
 
-    pub fn avoidance (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn avoidance(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -312,26 +378,32 @@ impl Bird {
             if self != vec[i] {
                 let dx = toroidal_distance(self.pos.x, vec[i].pos.x, WIDTH);
                 let dy = toroidal_distance(self.pos.y, vec[i].pos.y, HEIGTH);
-                let square = (dx*dx + dy*dy).sqrt();
+                let square = (dx * dx + dy * dy).sqrt();
                 count += 1;
-                x += dx/(square*square) + 1.0;
-                y += dy/(square*square) + 1.0;
+                x += dx / (square * square) + 1.0;
+                y += dy / (square * square) + 1.0;
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         } else {
-            let real = Real2D {x: 400.0*x, y: 400.0*y};
+            let real = Real2D {
+                x: 400.0 * x,
+                y: 400.0 * y,
+            };
             return real;
         }
     }
 
-    pub fn cohesion (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn cohesion(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -351,12 +423,18 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         } else {
-            let real = Real2D {x: -x/10.0, y: -y/10.0};
+            let real = Real2D {
+                x: -x / 10.0,
+                y: -y / 10.0,
+            };
             return real;
         }
     }
@@ -364,21 +442,21 @@ impl Bird {
     pub fn randomness(self) -> Real2D {
         let mut rng = rand::thread_rng();
         let r1: f64 = rng.gen();
-        let x = r1*2.0 -1.0;
+        let x = r1 * 2.0 - 1.0;
         let r2: f64 = rng.gen();
-        let y = r2*2.0 -1.0;
+        let y = r2 * 2.0 - 1.0;
 
-        let square = (x*x + y*y).sqrt();
+        let square = (x * x + y * y).sqrt();
         let real = Real2D {
-            x: 0.05*x/square,
-            y: 0.05*y/square,
+            x: 0.05 * x / square,
+            y: 0.05 * y / square,
         };
         return real;
     }
 
-    pub fn consistency (self, vec: &Vec<Bird>) -> Real2D {
+    pub fn consistency(self, vec: &Vec<Bird>) -> Real2D {
         if vec.is_empty() {
-            let real = Real2D {x: 0.0, y: 0.0};
+            let real = Real2D { x: 0.0, y: 0.0 };
             return real;
         }
 
@@ -399,12 +477,15 @@ impl Bird {
             }
         }
         if count > 0 {
-            x = x/count as f64;
-            y = y/count as f64;
-            let real = Real2D {x: -x/count as f64, y: y/count as f64};
+            x = x / count as f64;
+            y = y / count as f64;
+            let real = Real2D {
+                x: -x / count as f64,
+                y: y / count as f64,
+            };
             return real;
         } else {
-            let real = Real2D {x: x, y: y};
+            let real = Real2D { x: x, y: y };
             return real;
         }
     }
@@ -412,15 +493,18 @@ impl Bird {
 
 impl Agent for Bird {
     fn step(&mut self) {
-
-        let vec = GLOBAL_STATE.lock().unwrap().field1.get_neighbors_within_distance(self.pos, 10.0);
-    // {
-    //     let fpos = GLOBAL_STATE.lock().unwrap();
-    //     let fpos = fpos.field1.get_object_location(*self);
-    //     let fpos = fpos.unwrap();
-    //     println!("{} {} {} {}", self.id, self.pos,fpos,vec.len());
-    //
-    // }
+        let vec = GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .get_neighbors_within_distance(self.pos, 10.0);
+        // {
+        //     let fpos = GLOBAL_STATE.lock().unwrap();
+        //     let fpos = fpos.field1.get_object_location(*self);
+        //     let fpos = fpos.unwrap();
+        //     println!("{} {} {} {}", self.id, self.pos,fpos,vec.len());
+        //
+        // }
 
         let avoid = self.avoidance(&vec);
         let cohe = self.cohesion(&vec);
@@ -428,24 +512,34 @@ impl Agent for Bird {
         let cons = self.consistency(&vec);
         let mom = self.last_d;
 
-        let mut dx = COHESION*cohe.x + AVOIDANCE*avoid.x + CONSISTENCY*cons.x + RANDOMNESS*rand.x + MOMENTUM*mom.x;
-        let mut dy = COHESION*cohe.y + AVOIDANCE*avoid.y + CONSISTENCY*cons.y + RANDOMNESS*rand.y + MOMENTUM*mom.y;
+        let mut dx = COHESION * cohe.x
+            + AVOIDANCE * avoid.x
+            + CONSISTENCY * cons.x
+            + RANDOMNESS * rand.x
+            + MOMENTUM * mom.x;
+        let mut dy = COHESION * cohe.y
+            + AVOIDANCE * avoid.y
+            + CONSISTENCY * cons.y
+            + RANDOMNESS * rand.y
+            + MOMENTUM * mom.y;
 
-        let dis = (dx*dx + dy*dy).sqrt();
+        let dis = (dx * dx + dy * dy).sqrt();
         if dis > 0.0 {
-            dx = dx/dis*JUMP;
-            dy = dy/dis*JUMP;
-
+            dx = dx / dis * JUMP;
+            dy = dy / dis * JUMP;
         }
 
-        let _lastd = Real2D {x: dx, y:dy};
+        let _lastd = Real2D { x: dx, y: dy };
         let loc_x = toroidal_transform(self.pos.x + dx, WIDTH);
         let loc_y = toroidal_transform(self.pos.y + dy, WIDTH);
 
-        self.pos = Real2D{x: loc_x, y: loc_y};
+        self.pos = Real2D { x: loc_x, y: loc_y };
 
-        GLOBAL_STATE.lock().unwrap().field1.set_object_location(*self, Real2D{x: loc_x, y: loc_y});
-
+        GLOBAL_STATE
+            .lock()
+            .unwrap()
+            .field1
+            .set_object_location(*self, Real2D { x: loc_x, y: loc_y });
     }
 }
 
@@ -467,7 +561,7 @@ impl PartialEq for Bird {
     }
 }
 
-impl Location2D for Bird {
+impl Location2D<Real2D> for Bird {
     fn get_location(self) -> Real2D {
         self.pos
     }
@@ -482,7 +576,6 @@ impl fmt::Display for Bird {
         write!(f, "{}", self.id)
     }
 }
-
 
 //
 // fn distance(pos1: &Real2D, pos2: &Real2D, dim1: f64, dim2: f64, tor: bool) -> f64{

--- a/tests/hashmap_test.rs
+++ b/tests/hashmap_test.rs
@@ -1,12 +1,12 @@
-use std::hash::Hasher;
-use std::hash::Hash;
 use std::collections::HashMap;
+use std::hash::Hash;
+use std::hash::Hasher;
 
 #[test]
 fn hash_test_1() {
-    let libro1 = Libro{id: 1, costo: 2.0};
-    let libro2 = Libro{id: 2, costo: 6.0};
-//    let libro3 = Libro{id: 3, costo: 8.0};
+    let libro1 = Libro { id: 1, costo: 2.0 };
+    let libro2 = Libro { id: 2, costo: 6.0 };
+    //    let libro3 = Libro{id: 3, costo: 8.0};
 
     let mut map = HashMap::new();
     map.insert(libro1.clone(), 1);
@@ -19,9 +19,7 @@ fn hash_test_1() {
     assert_eq!(4, *map.get(&libro1).unwrap());
 
     assert_eq!(2, map.len());
-
 }
-
 
 #[derive(Debug, Clone)]
 pub struct Libro {
@@ -29,7 +27,7 @@ pub struct Libro {
     pub costo: f64,
 }
 
-impl Hash for Libro{
+impl Hash for Libro {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,

--- a/tests/schedule.rs
+++ b/tests/schedule.rs
@@ -1,13 +1,13 @@
 extern crate priority_queue;
 
-use std::hash::Hasher;
-use std::hash::Hash;
-use abm::location::Real2D;
-use abm::field2D::Field2D;
-use std::fmt;
 use abm::agent::Agent;
-use abm::schedule::Schedule;
+use abm::field_2d::Field2D;
 use abm::location::Location2D;
+use abm::location::Real2D;
+use abm::schedule::Schedule;
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
 
 static STEP: u128 = 10;
 // static NUM_AGENT: u128 = 2;
@@ -20,7 +20,6 @@ static STEP: u128 = 10;
 
 #[test]
 fn field_2d_test_1() {
-
     let width = 100.0;
     let heigth = 100.0;
     let discretization = 0.7;
@@ -32,49 +31,48 @@ fn field_2d_test_1() {
 
     let data_ref = &data as *const State;
     unsafe {
-        let bird1 = Bird::new(1, Real2D{x: 10.5, y: 10.0}, &*data_ref);
-        let bird2 = Bird::new(2, Real2D{x: 10.0, y: 10.0}, &*data_ref);
+        let bird1 = Bird::new(1, Real2D { x: 10.5, y: 10.0 }, &*data_ref);
+        let bird2 = Bird::new(2, Real2D { x: 10.0, y: 10.0 }, &*data_ref);
 
-        data.field1.set_object_location(bird1.clone(), bird1.pos.clone());
+        data.field1
+            .set_object_location(bird1.clone(), bird1.pos.clone());
         let pos = match data.field1.get_object_location(bird1.clone()) {
             Some(i) => i,
             None => panic!("no location"),
         };
 
-        let real_pos = Real2D {x: 10.5, y: 10.0};
+        let real_pos = Real2D { x: 10.5, y: 10.0 };
         assert_eq!(real_pos, *pos);
 
-        data.field1.set_object_location(bird1.clone(), Real2D{x: 10.0, y: 10.0});
+        data.field1
+            .set_object_location(bird1.clone(), Real2D { x: 10.0, y: 10.0 });
         let pos = match data.field1.get_object_location(bird1.clone()) {
             Some(i) => i,
             None => panic!("no location"),
         };
 
-        let real_pos = Real2D {x: 10.0, y: 10.0};
+        let real_pos = Real2D { x: 10.0, y: 10.0 };
         assert_eq!(real_pos, *pos);
 
-        data.field1.set_object_location(bird2.clone(), bird2.pos.clone());
+        data.field1
+            .set_object_location(bird2.clone(), bird2.pos.clone());
 
         let num = data.field1.num_objects_at_location(real_pos);
         assert_eq!(2, num);
 
         schedule.schedule_repeating(bird1, 5.0, 100);
         schedule.schedule_repeating(bird2, 5.0, 100);
-
-
     }
 
     assert!(!schedule.events.is_empty());
 
-    for _ in 1..STEP{
+    for _ in 1..STEP {
         schedule.step();
     }
-
 }
 
 #[test]
 fn field_2d_test_2() {
-
     let width = 10.0;
     let heigth = 10.0;
     let discretization = 0.5;
@@ -86,19 +84,26 @@ fn field_2d_test_2() {
 
     let data_ref = &data as *const State;
     unsafe {
-        let bird1 = Bird::new(1, Real2D{x: 5.5, y: 5.5}, &*data_ref);
-        let bird2 = Bird::new(2, Real2D{x: 4.0, y: 4.0}, &*data_ref);
-        let bird3 = Bird::new(3, Real2D{x: 5.2, y: 5.2}, &*data_ref);
-        let bird4 = Bird::new(4, Real2D{x: 5.2, y: 2.2}, &*data_ref);
-        let bird5 = Bird::new(5, Real2D{x: 5.2, y: 2.1}, &*data_ref);
+        let bird1 = Bird::new(1, Real2D { x: 5.5, y: 5.5 }, &*data_ref);
+        let bird2 = Bird::new(2, Real2D { x: 4.0, y: 4.0 }, &*data_ref);
+        let bird3 = Bird::new(3, Real2D { x: 5.2, y: 5.2 }, &*data_ref);
+        let bird4 = Bird::new(4, Real2D { x: 5.2, y: 2.2 }, &*data_ref);
+        let bird5 = Bird::new(5, Real2D { x: 5.2, y: 2.1 }, &*data_ref);
 
-        data.field1.set_object_location(bird1.clone(), bird1.pos.clone());
-        data.field1.set_object_location(bird2.clone(), bird2.pos.clone());
-        data.field1.set_object_location(bird3.clone(), bird3.pos.clone());
-        data.field1.set_object_location(bird4.clone(), bird4.pos.clone());
-        data.field1.set_object_location(bird5.clone(), bird5.pos.clone());
+        data.field1
+            .set_object_location(bird1.clone(), bird1.pos.clone());
+        data.field1
+            .set_object_location(bird2.clone(), bird2.pos.clone());
+        data.field1
+            .set_object_location(bird3.clone(), bird3.pos.clone());
+        data.field1
+            .set_object_location(bird4.clone(), bird4.pos.clone());
+        data.field1
+            .set_object_location(bird5.clone(), bird5.pos.clone());
 
-        let vec = data.field1.get_neighbors_within_distance(Real2D{x: 5.2, y:5.2}, 3.0);
+        let vec = data
+            .field1
+            .get_neighbors_within_distance(Real2D { x: 5.2, y: 5.2 }, 3.0);
         assert_eq!(4, vec.len());
 
         // bird2.pos = Real2D {x: 5.3, y:5.3};
@@ -107,19 +112,22 @@ fn field_2d_test_2() {
         // let vec = data.field1.get_neighbors_within_distance(Real2D{x: 5.2, y:5.2}, 3.0);
         // assert_eq!(5, vec.len());
 
-        let bird6 = Bird::new(6, Real2D{x: 0.1, y: 0.1}, &*data_ref);
-        data.field1.set_object_location(bird6.clone(), bird6.pos.clone());
+        let bird6 = Bird::new(6, Real2D { x: 0.1, y: 0.1 }, &*data_ref);
+        data.field1
+            .set_object_location(bird6.clone(), bird6.pos.clone());
 
-        let vec = data.field1.get_neighbors_within_distance(Real2D{x: 5.2, y:5.2}, 5.0);
+        let vec = data
+            .field1
+            .get_neighbors_within_distance(Real2D { x: 5.2, y: 5.2 }, 5.0);
         assert_eq!(5, vec.len());
 
-        let num = data.field1.num_objects_at_location(Real2D{x: 5.0, y:2.0});
+        let num = data
+            .field1
+            .num_objects_at_location(Real2D { x: 5.0, y: 2.0 });
         assert_eq!(2, num);
 
         //schedule.schedule_repeating(bird1, 5.0, 100);
         //schedule.schedule_repeating(bird2, 5.0, 100);
-
-
     }
 
     // assert!(!schedule.events.is_empty());
@@ -127,9 +135,7 @@ fn field_2d_test_2() {
     // for _ in 1..STEP{
     //     schedule.step();
     // }
-
 }
-
 
 #[test]
 fn field_2d_test_3() {
@@ -145,11 +151,13 @@ fn field_2d_test_3() {
     let bird2;
     let data_ref = &data as *const State;
     unsafe {
-        bird1 = Bird::new(1, Real2D{x: 5.5, y: 5.5}, &*data_ref);
-        bird2 = Bird::new(2, Real2D{x: 4.0, y: 4.0}, &*data_ref);
+        bird1 = Bird::new(1, Real2D { x: 5.5, y: 5.5 }, &*data_ref);
+        bird2 = Bird::new(2, Real2D { x: 4.0, y: 4.0 }, &*data_ref);
 
-        data.field1.set_object_location(bird1.clone(), bird1.pos.clone());
-        data.field1.set_object_location(bird2.clone(), bird2.pos.clone());
+        data.field1
+            .set_object_location(bird1.clone(), bird1.pos.clone());
+        data.field1
+            .set_object_location(bird2.clone(), bird2.pos.clone());
     }
 
     let pos_b1 = match data.field1.get_object_location(bird1.clone()) {
@@ -158,7 +166,7 @@ fn field_2d_test_3() {
     };
     assert_eq!(bird1.pos, *pos_b1);
 
-    let new_pos = Real2D{x:7.0, y:9.2};
+    let new_pos = Real2D { x: 7.0, y: 9.2 };
     bird1.pos = new_pos.clone();
     data.field1.set_object_location(bird1.clone(), new_pos);
 
@@ -167,8 +175,6 @@ fn field_2d_test_3() {
         None => panic!("non trovato"),
     };
     assert_eq!(bird1.pos, *pos_b1);
-
-
 }
 //
 // fn test_schedule_3() {
@@ -211,12 +217,11 @@ fn field_2d_test_3() {
 //     assert_eq!(Some(x3), schedule.events.pop());
 // }
 
-
-pub struct State<'a>{
+pub struct State<'a> {
     pub field1: Field2D<Bird<'a>>,
 }
 
-impl<'a> State<'a>{
+impl<'a> State<'a> {
     pub fn new(w: f64, h: f64, d: f64, t: bool) -> State<'a> {
         State {
             field1: Field2D::new(w, h, d, t),
@@ -241,13 +246,9 @@ impl<'a> Hash for Bird<'a> {
     }
 }
 
-impl<'a > Bird<'a> {
+impl<'a> Bird<'a> {
     pub fn new(id: u128, pos: Real2D, state: &'a State) -> Self {
-        Bird {
-            id,
-            pos,
-            state,
-        }
+        Bird { id, pos, state }
     }
 }
 
@@ -261,21 +262,16 @@ impl<'a> PartialEq for Bird<'a> {
 
 impl<'a> Agent for Bird<'a> {
     fn step(&mut self) {
-        let pos = Real2D {
-            x: 1.0,
-            y: 2.0,
-        };
+        let pos = Real2D { x: 1.0, y: 2.0 };
 
         let vec = self.state.field1.get_neighbors_within_distance(pos, 5.0);
         for elem in vec {
             println!("{}", elem.id);
         }
-
     }
-
 }
 
-impl<'a > Location2D for Bird<'a> {
+impl<'a> Location2D<Real2D> for Bird<'a> {
     fn get_location(self) -> Real2D {
         self.pos
     }


### PR DESCRIPTION
- Formatted the whole project with the Rustfmt tool, in accordance to the Rust style guidelines
- Resolved all the warnings thrown by the unnecessary boids.rs cargo binary setting, unused things and unnecessary declarations
- Refactors Location2D to be generic over a type T bound by Display, Copy, Eq and PartialEq (such as Real2D and Int2D)
- Adds two new data structures:
  - Grid2D, a wrapper over a HashMap, with agents as keys and their locations as values,
  - SimpleGrid2D, a generic matrix over cloneable types wrapped in an Option (None marks a cell as empty)

Possible improvements:
- Use Location2D on the Grid implementations to constrain Grid2D keys, so that they must be bound by the Location2D<Int2D> trait to be used